### PR TITLE
update readme with correct info about py versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 In order to get started on this project, I recommend you watch the section on **Scripting** in the [Python course](https://www.udemy.com/course/complete-python-developer-zero-to-mastery/?couponCode=LEVELUPZTM). We talk about ```sys.argv``` and ```Pillow``` library (Image processing) in that section which would help you!
 
 1. Clone this repo
-2. Make sure you have Python 3 installed on your machine
+2. Make sure you have Python v3.6 (or greater) installed on your machine
 3. Install [Pillow library](https://pillow.readthedocs.io/en/stable/installation.html)
 4. run the command: `python3 make_art.py zeroToMasteryIcon.png 1` or `python3 make_art.py zeroToMasteryIcon.png 2` for a more clear output [zoomout a little bit]
 5. Stare with amazement 😮


### PR DESCRIPTION
Py3 before v3.6 will not work - mostly due to f"string" as mentioned in this https://www.python.org/dev/peps/pep-0498/ , maybe a few other things, but this bit me straight away when i fired up an older interpreter.