### PR TITLE
Update/save some memory

### DIFF
--- a/make_art.py
+++ b/make_art.py
@@ -4,8 +4,7 @@
 # code modified to work with Python 3 by @aneagoie
 from PIL import Image
 ASCII_CHARS = ['#', '?', ' ', '.', '=', '+', '.', '*', '3', '&', '@']
-from guppy import hpy
-h = hpy()
+
 
 def scale_image(image, clearity):
     """Resizes an image preserving the aspect ratio.
@@ -30,10 +29,8 @@ def map_pixels_to_ascii_chars(image, range_width=25):
     0-255 is divided into 11 ranges of 25 pixels each.
     """
 
-    pixels_in_image = list(image.getdata())
     pixels_to_chars = [ASCII_CHARS[int(pixel_value/range_width)] for pixel_value in
-                       pixels_in_image]
-    print(h.heap())
+                       image.getdata()]
     return "".join(pixels_to_chars)
 
 

--- a/make_art.py
+++ b/make_art.py
@@ -4,7 +4,8 @@
 # code modified to work with Python 3 by @aneagoie
 from PIL import Image
 ASCII_CHARS = ['#', '?', ' ', '.', '=', '+', '.', '*', '3', '&', '@']
-
+from guppy import hpy
+h = hpy()
 
 def scale_image(image, clearity):
     """Resizes an image preserving the aspect ratio.
@@ -32,7 +33,7 @@ def map_pixels_to_ascii_chars(image, range_width=25):
     pixels_in_image = list(image.getdata())
     pixels_to_chars = [ASCII_CHARS[int(pixel_value/range_width)] for pixel_value in
                        pixels_in_image]
-
+    print(h.heap())
     return "".join(pixels_to_chars)
 
 


### PR DESCRIPTION
We can iterate over the getdata call saving a bit of memory, small enough for now but if you were to run this with some large images/parameters you could seem performance issues.

Before:
```
Partition of a set of 58214 objects. Total size = 7256003 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0  17814  31  1585025  22   1585025  22 str
     1  14810  25  1230240  17   2815265  39 tuple
     2   7710  13   566150   8   3381415  47 bytes
     3   3806   7   549808   8   3931223  54 types.CodeType
     4   3566   6   513504   7   4444727  61 function
     5    584   1   487720   7   4932447  68 type
     6    584   1   325056   4   5257503  72 dict of type
     7      2   0   262512   4   5520015  76 _io.BufferedWriter
     8    487   1   252632   3   5772647  80 dict (no owner)
     9    151   0   241456   3   6014103  83 dict of module
<136 more rows. Type e.g. '_.more' to view.>
```

After:
```
Partition of a set of 58153 objects. Total size = 7164133 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0  17813  31  1584961  22   1584961  22 str
     1  14810  25  1230224  17   2815185  39 tuple
     2   7710  13   566140   8   3381325  47 bytes
     3   3806   7   549808   8   3931133  55 types.CodeType
     4   3566   6   513504   7   4444637  62 function
     5    584   1   487720   7   4932357  69 type
     6    584   1   325056   5   5257413  73 dict of type
     7      2   0   262512   4   5519925  77 _io.BufferedWriter
     8    487   1   252632   4   5772557  81 dict (no owner)
     9    151   0   241456   3   6014013  84 dict of module
```


Note:
Heap was recorded using guppy3 (https://pypi.org/project/guppy3/)